### PR TITLE
Disable sanitizers in RPM build

### DIFF
--- a/rpm/template.spec.em
+++ b/rpm/template.spec.em
@@ -46,6 +46,7 @@ mkdir -p obj-%{_target_platform} && cd obj-%{_target_platform}
     -DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
     -DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
     -DSETUPTOOLS_DEB_LAYOUT=OFF \
+    -DDISABLE_SANITIZERS=ON \
     ..
 
 %make_build


### PR DESCRIPTION
I'm not sure how this is working on Ubuntu - I would guess that the sanitizer libraries are an implicit dependency of something somewhere. In any case, that isn't true on RHEL, and I'm not even sure if the required sanitizers are available.

**NOTE**: If this PR is squash-merged, be sure to drop the PR number from the end of the commit message, or every time this patch is re-applied by Bloom, it will be back-linked from this PR.