### PR TITLE
Override FetchContent flag to make sure that content is populated.

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -35,6 +35,7 @@ override_dh_auto_configure:
 		-DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" \
 		-DAMENT_PREFIX_PATH="@(InstallationPrefix)" \
 		-DCMAKE_PREFIX_PATH="@(InstallationPrefix)" \
+		-DFETCHCONTENT_FULLY_DISCONNECTED=OFF \
 		$(BUILD_TESTING_ARG)
 
 override_dh_auto_build:


### PR DESCRIPTION
This flag now seems to be ON by default in our deb builds but our vendor packages do not currently pre-populate fetchcontent contents.

I'm applying this patch at the template level assuming that even if it does not affect Debian as-of bookworm it will in the future and is benign otherwise. 